### PR TITLE
Add support for orientation option

### DIFF
--- a/lib/orientation.h
+++ b/lib/orientation.h
@@ -1,0 +1,10 @@
+#ifndef ORIENTATION_H
+#define ORIENTATION_H
+
+#define ORIENTATION_MAP \
+  {{"portrait", PrintParameters::Portrait}, \
+   {"landscape", PrintParameters::Landscape}, \
+   {"reverse-portrait", PrintParameters::ReversePortrait}, \
+   {"reverse-landscape", PrintParameters::ReverseLandscape}}
+
+#endif //ORIENTATION_H

--- a/lib/ppm2pwg.cpp
+++ b/lib/ppm2pwg.cpp
@@ -203,6 +203,11 @@ void make_pwg_hdr(Bytestream& outBts, const PrintParameters& params, bool backsi
     outHdr.MediaPosition = media_position_from_name(params.mediaPosition);
   }
 
+  outHdr.Orientation = (params.orientation == PrintParameters::Portrait ? PwgPgHdr::Portrait
+                     : (params.orientation == PrintParameters::Landscape ? PwgPgHdr::Landscape
+                     : (params.orientation == PrintParameters::ReversePortrait ? PwgPgHdr::ReversePortrait
+                     : (params.orientation == PrintParameters::ReverseLandscape ? PwgPgHdr::ReverseLandscape
+                     : PwgPgHdr::Portrait)))); // portrait means "no rotation" and is a safe default
 
   if(verbose)
   {

--- a/lib/printparameters.h
+++ b/lib/printparameters.h
@@ -80,6 +80,16 @@ public:
     TwoSidedShortEdge
   };
 
+  enum Orientation
+  {
+    Portrait = 0,
+    Landscape,
+    ReversePortrait,
+    ReverseLandscape
+  };
+
+  Orientation orientation = Portrait;
+
   std::string mediaType;
   std::string mediaPosition;
 

--- a/utils/pdf2printable_main.cpp
+++ b/utils/pdf2printable_main.cpp
@@ -5,6 +5,7 @@
 
 #include "pdf2printable.h"
 #include "argget.h"
+#include "orientation.h"
 
 #define HELPTEXT "Options from 'resolution' and onwards only affect raster output formats.\n" \
                  "Use \"-\" as filename for stdin/stdout."
@@ -91,6 +92,9 @@ int main(int argc, char** argv)
   SwitchArg<bool> antiAliasOpt(params.antiAlias, {"-aa", "--antaialias"}, "Enable antialiasing in rasterization");
   SwitchArg<std::string> mediaTypeOpt(params.mediaType, {"-mt", "--media-type"}, "The media type, e.g.: card-stock");
   SwitchArg<std::string> mediaPositionOpt(params.mediaPosition, {"-mp", "--media-pos"}, "The media position, e.g.: Top");
+  EnumSwitchArg<PrintParameters::Orientation> orientationOpt(params.orientation, ORIENTATION_MAP,
+                                                                 {"-o", "--orientation"},
+                                                                 "Orientation, one of: portrait (default), landscape, reverse-portrait, reverse-landscape");
 
   PosArg pdfArg(infile, "PDF-file");
   PosArg outArg(outfile, "out-file", true);
@@ -99,7 +103,7 @@ int main(int argc, char** argv)
                &copiesOpt, /*&pageCopiesOpt,*/ &paperSizeOpt, &resolutionOpt,
                &resolutionXOpt, &resolutionYOpt, &duplexOpt, &tumbleOpt,
                &backXformOpt, &colorModeOpt, &qualityOpt, &antiAliasOpt,
-               &mediaTypeOpt, &mediaPositionOpt},
+               &mediaTypeOpt, &mediaPositionOpt, &orientationOpt},
               {&pdfArg, &outArg});
 
   bool correctArgs = args.get_args(argc, argv);

--- a/utils/ppm2pwg_main.cpp
+++ b/utils/ppm2pwg_main.cpp
@@ -7,6 +7,7 @@
 
 #include "ppm2pwg.h"
 #include "argget.h"
+#include "orientation.h"
 
 inline void ignore_comments(std::istream* in)
 {
@@ -64,6 +65,9 @@ int PPM2PWG_MAIN(int argc, char** argv)
                                                      "Quality setting in raster header (draft/normal/high)");
   SwitchArg<std::string> mediaTypeOpt(params.mediaType, {"--media-type"}, "The media type, e.g.: card-stock");
   SwitchArg<std::string> mediaPositionOpt(params.mediaPosition, {"-mp", "--media-pos"}, "The media position, e.g.: Top");
+  EnumSwitchArg<PrintParameters::Orientation> orientationOpt(params.orientation, ORIENTATION_MAP,
+                                                             {"-o", "--orientation"},
+                                                             "Orientation, one of: portrait (default), landscape, reverse-portrait, reverse-landscape");
 
   PosArg inArg(inFile, "in-file");
   PosArg outArg(outFile, "out-file");
@@ -71,7 +75,7 @@ int PPM2PWG_MAIN(int argc, char** argv)
   ArgGet args({&helpOpt, &verboseOpt, &urfOpt, &pagesOpt, &paperSizeOpt,
                &resolutionOpt, &resolutionXOpt, &resolutionYOpt,
                &duplexOpt, &tumbleOpt, &backXformOpt, &qualityOpt,
-               &mediaTypeOpt, &mediaPositionOpt},
+               &mediaTypeOpt, &mediaPositionOpt, &orientationOpt},
               {&inArg, &outArg});
 
   bool correctArgs = args.get_args(argc, argv);


### PR DESCRIPTION
This embeds the `Orientation` value in the PWG header, but it seemingly has no effect (at least on the Epson printer I've specified). However, it is definitely being embedded so this could be a quirk with the printer.